### PR TITLE
Enable ITs to run on the command line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,20 @@
   </dependencyManagement>
 
   <build>
-
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.1.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
This allows running from the command line to execute the performance test and not just from the IDE so, for example, executing `mvn verify` will run the test.
